### PR TITLE
feat(cloudflare-tunnel): add support for extraEnv to be passed to containers

### DIFF
--- a/charts/cloudflare-tunnel/Chart.yaml
+++ b/charts/cloudflare-tunnel/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.6
+version: 0.1.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cloudflare-tunnel/README.md
+++ b/charts/cloudflare-tunnel/README.md
@@ -61,6 +61,7 @@ For more settings of ingresses please consult [official cloudflare docs](https:/
 | cloudflared.serviceMonitor.enabled | bool | `false` |  |
 | cloudflared.tunnel | string | `nil` | tunnel UUID. Tunnel name will not work. Get it with 'cloudflared tunnel list' |
 | cloudflared.tunnelSecret | string | `"tunnel-credentials"` | name of secret with stored tunnel credentials |
+| extraEnv | list | `[]` | additional container environment variables |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"cloudflare/cloudflared"` | overrides default image |

--- a/charts/cloudflare-tunnel/templates/deployment.yaml
+++ b/charts/cloudflare-tunnel/templates/deployment.yaml
@@ -32,6 +32,10 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            {{- with .Values.extraEnv }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             - name: metrics
               containerPort: 2000

--- a/charts/cloudflare-tunnel/values.yaml
+++ b/charts/cloudflare-tunnel/values.yaml
@@ -51,6 +51,14 @@ serviceAccount:
 # -- pod annotations
 podAnnotations: {}
 
+# -- additional container environment variables
+extraEnv: []
+## Example: Cloudflare Edge ip address version to connect with. {4, 6, auto}
+## extraEnv:
+##   - name: TUNNEL_EDGE_IP_VERSION
+##     value: 6
+##
+
 # -- pod security context
 podSecurityContext: {}
   # fsGroup: 2000


### PR DESCRIPTION
This would be useful to future proof for additional configuration variables introduced. For example https://github.com/cloudflare/cloudflared/commit/ee80e5583367a22441f42ea70c3835a595ba8d5f