### PR TITLE
yopass: enable service annotations

### DIFF
--- a/charts/yopass/templates/service.yaml
+++ b/charts/yopass/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "yopass.fullname" . }}
   labels:
     {{- include "yopass.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/yopass/values.yaml
+++ b/charts/yopass/values.yaml
@@ -40,6 +40,8 @@ service:
   type: ClusterIP
   # -- service port
   port: 1337
+  # -- additional annotations for service
+  annotations: {}
 
 ingress:
   # -- enables ingress


### PR DESCRIPTION
Allow to annotate yopass service, e.g. to [enforce NEGs on GKE](https://cloud.google.com/kubernetes-engine/docs/how-to/container-native-load-balancing#create_service).