### PR TITLE
Include Pod Disruption Budget configuration for cloudflare-tunnel Helm Chart

### DIFF
--- a/charts/cloudflare-tunnel/Chart.yaml
+++ b/charts/cloudflare-tunnel/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.10
+version: 0.1.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cloudflare-tunnel/README.md
+++ b/charts/cloudflare-tunnel/README.md
@@ -72,6 +72,9 @@ For more settings of ingresses please consult [official cloudflare docs](https:/
 | nodeSelector | object | `{}` | node selector rules |
 | podAnnotations | object | `{}` | pod annotations |
 | podDisruptionBudget | object | `{"create":false,"maxUnavailable":"","minAvailable":1}` | Pod Disruption Budget configuration |
+| podDisruptionBudget.create | bool | `false` | Specifies whether a PodDisruptionBudget should be created |
+| podDisruptionBudget.maxUnavailable | string | `""` | Max number of pods that can be unavailable after the eviction |
+| podDisruptionBudget.minAvailable | int | `1` | Min number of pods that must still be available after the eviction |
 | podSecurityContext | object | `{}` | pod security context |
 | replicaCount | int | `1` | Amount of replicas. Be aware that >1 replicas requires paid cloudflare loadbalancer subscription |
 | resources | object | `{}` | pod limits/requests |

--- a/charts/cloudflare-tunnel/README.md
+++ b/charts/cloudflare-tunnel/README.md
@@ -1,6 +1,6 @@
 # cloudflare-tunnel
 
-![Version: 0.1.10](https://img.shields.io/badge/Version-0.1.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2022.8.0](https://img.shields.io/badge/AppVersion-2022.8.0-informational?style=flat-square)
+![Version: 0.1.11](https://img.shields.io/badge/Version-0.1.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2022.8.0](https://img.shields.io/badge/AppVersion-2022.8.0-informational?style=flat-square)
 
 Manage and use cloudflare tunnels (also known as argo tunnels) on k8s cluster
 
@@ -71,7 +71,7 @@ For more settings of ingresses please consult [official cloudflare docs](https:/
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` | node selector rules |
 | podAnnotations | object | `{}` | pod annotations |
-| podDisruptionBudget.create | bool | `false` | Specifies whether a PodDisruptionBudget should be created  |
+| podDisruptionBudget | object | `{"create":false,"maxUnavailable":"","minAvailable":1}` | Pod Disruption Budget configuration |
 | podSecurityContext | object | `{}` | pod security context |
 | replicaCount | int | `1` | Amount of replicas. Be aware that >1 replicas requires paid cloudflare loadbalancer subscription |
 | resources | object | `{}` | pod limits/requests |

--- a/charts/cloudflare-tunnel/README.md
+++ b/charts/cloudflare-tunnel/README.md
@@ -71,6 +71,7 @@ For more settings of ingresses please consult [official cloudflare docs](https:/
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` | node selector rules |
 | podAnnotations | object | `{}` | pod annotations |
+| podDisruptionBudget.create | bool | `false` | Specifies whether a PodDisruptionBudget should be created  |
 | podSecurityContext | object | `{}` | pod security context |
 | replicaCount | int | `1` | Amount of replicas. Be aware that >1 replicas requires paid cloudflare loadbalancer subscription |
 | resources | object | `{}` | pod limits/requests |

--- a/charts/cloudflare-tunnel/templates/poddisruptionbudget.yaml
+++ b/charts/cloudflare-tunnel/templates/poddisruptionbudget.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "cloudflare-tunnel.labels" . | nindent 4 }}
 spec:
   {{- if .Values.podDisruptionBudget.minAvailable }}
-  minAvailable: {{ .Values.master.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
   {{- end }}
   {{- if .Values.podDisruptionBudget.maxUnavailable }}
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}

--- a/charts/cloudflare-tunnel/templates/poddisruptionbudget.yaml
+++ b/charts/cloudflare-tunnel/templates/poddisruptionbudget.yaml
@@ -13,5 +13,6 @@ spec:
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
   {{- end }}
   selector:
-    {{- include "cloudflare-tunnel.selectorLabels" . | nindent 4 }}
+    matchLabels:
+      {{- include "cloudflare-tunnel.selectorLabels" . | nindent 6 }}
 {{- end }}

--- a/charts/cloudflare-tunnel/templates/poddisruptionbudget.yaml
+++ b/charts/cloudflare-tunnel/templates/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podDisruptionBudget.create }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "cloudflare-tunnel.fullname" . }}

--- a/charts/cloudflare-tunnel/templates/poddisruptionbudget.yaml
+++ b/charts/cloudflare-tunnel/templates/poddisruptionbudget.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.podDisruptionBudget.create }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "cloudflare-tunnel.fullname" . }}
+  labels:
+    {{- include "cloudflare-tunnel.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.master.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    {{- include "cloudflare-tunnel.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/cloudflare-tunnel/values.yaml
+++ b/charts/cloudflare-tunnel/values.yaml
@@ -74,11 +74,11 @@ securityContext: {}
 
 # -- Pod Disruption Budget configuration
 podDisruptionBudget:
-  ## -- Specifies whether a PodDisruptionBudget should be created
+  # -- Specifies whether a PodDisruptionBudget should be created
   create: false
-  ## -- Min number of pods that must still be available after the eviction
+  # -- Min number of pods that must still be available after the eviction
   minAvailable: 1
-  ## -- Max number of pods that can be unavailable after the eviction
+  # -- Max number of pods that can be unavailable after the eviction
   maxUnavailable: ""
 
 # -- pod limits/requests

--- a/charts/cloudflare-tunnel/values.yaml
+++ b/charts/cloudflare-tunnel/values.yaml
@@ -72,6 +72,15 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
+# -- Pod Disruption Budget configuration
+podDisruptionBudget:
+  ## -- Specifies whether a PodDisruptionBudget should be created
+  create: false
+  ## -- Min number of pods that must still be available after the eviction
+  minAvailable: 1
+  ## -- Max number of pods that can be unavailable after the eviction
+  maxUnavailable: ""
+
 # -- pod limits/requests
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
This Pull Request includes Pod Disruption Budget configuration for `cloudflare-tunnel` Helm Chart.
ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets

With PDB enabled you can make sure that the configured number of pods remains alive in evictions, node drains etc and limit the possibility of losing the connection in the tunnel.