### PR TITLE
Add extraArgs support for kube-web-view

### DIFF
--- a/charts/kube-web-view/templates/deployment.yaml
+++ b/charts/kube-web-view/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            - --port=8080
+            {{- toYaml .Values.extraArgs | nindent 12 }}
           ports:
             - name: http
               containerPort: 8080


### PR DESCRIPTION
In order to allow more args to be passed to the container, we need to enable the ones provided in the values to be listed in the template.