### PR TITLE
Add genericRules support for pyrra

### DIFF
--- a/charts/pyrra/Chart.yaml
+++ b/charts/pyrra/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/pyrra/Chart.yaml
+++ b/charts/pyrra/Chart.yaml
@@ -16,7 +16,6 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-=======
 version: 0.4.2
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/pyrra/README.md
+++ b/charts/pyrra/README.md
@@ -1,6 +1,6 @@
 # pyrra
 
-![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.5.1](https://img.shields.io/badge/AppVersion-v0.5.1-informational?style=flat-square)
+![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.5.1](https://img.shields.io/badge/AppVersion-v0.5.1-informational?style=flat-square)
 
 SLO manager and alert generator
 

--- a/charts/pyrra/README.md
+++ b/charts/pyrra/README.md
@@ -1,6 +1,6 @@
 # pyrra
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.0](https://img.shields.io/badge/AppVersion-0.6.0-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.0](https://img.shields.io/badge/AppVersion-0.6.0-informational?style=flat-square)
 
 SLO manager and alert generator
 

--- a/charts/pyrra/README.md
+++ b/charts/pyrra/README.md
@@ -1,6 +1,6 @@
 # pyrra
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.0](https://img.shields.io/badge/AppVersion-0.6.0-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.0](https://img.shields.io/badge/AppVersion-0.6.0-informational?style=flat-square)
 
 SLO manager and alert generator
 
@@ -13,6 +13,7 @@ Additionaly, you (most likely) will need to specify prometheusExternalUrl with U
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | fullnameOverride | string | `""` | Overrides helm-generated chart fullname |
+| genericRuler.enabled | boolean | `false` | Generats Pyrra generic recording rules |
 | image.pullPolicy | string | `"IfNotPresent"` | Overrides pullpolicy |
 | image.repository | string | `"ghcr.io/pyrra-dev/pyrra"` | Overrides the image repository |
 | image.tag | string | `"v0.5.0"` | Overrides the image tag |

--- a/charts/pyrra/README.md
+++ b/charts/pyrra/README.md
@@ -13,7 +13,7 @@ Additionaly, you (most likely) will need to specify prometheusExternalUrl with U
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | fullnameOverride | string | `""` | Overrides helm-generated chart fullname |
-| genericRuler.enabled | boolean | `false` | Generats Pyrra generic recording rules |
+| genericRules.enabled | boolean | `false` | Generats Pyrra generic recording rules |
 | image.pullPolicy | string | `"IfNotPresent"` | Overrides pullpolicy |
 | image.repository | string | `"ghcr.io/pyrra-dev/pyrra"` | Overrides the image repository |
 | image.tag | string | `"v0.5.0"` | Overrides the image tag |

--- a/charts/pyrra/templates/deployment.yaml
+++ b/charts/pyrra/templates/deployment.yaml
@@ -32,6 +32,9 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - kubernetes
+            {{- if .Values.genericRules.enabled }}
+            - --generic-rules
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
         - name: {{ .Chart.Name }}

--- a/charts/pyrra/values.yaml
+++ b/charts/pyrra/values.yaml
@@ -80,3 +80,7 @@ tolerations: {}
 serviceMonitor:
   # -- enables servicemonitor for server monitoring
   enabled: false
+
+genericRules: 
+  # -- enables generate Pyrra generic recording rules. Pyrra generates metrics with the same name for each SLO.
+  enabled: false


### PR DESCRIPTION
In version v0.5.0, Pyrra supports [generic recording rules](https://github.com/pyrra-dev/pyrra/pull/420). This is mainly so that creating a [Grafana](https://github.com/pyrra-dev/pyrra/tree/main/examples/grafana#generic-rules) dashboard is possible with metrics generated by Pyrra. 

The new field in the values enables pass this parameter for those who want to have these recording rules.  It is just a boolean and if  set to true the argument is used in the kubernetes component of the deployment. 