### PR TITLE
Control cloudflared arguments in values file

### DIFF
--- a/charts/cloudflare-tunnel/Chart.yaml
+++ b/charts/cloudflare-tunnel/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cloudflare-tunnel/README.md
+++ b/charts/cloudflare-tunnel/README.md
@@ -63,6 +63,7 @@ For more settings of ingresses please consult [official cloudflare docs](https:/
 | cloudflared.tunnel | string | `nil` | tunnel UUID. Tunnel name will not work. Get it with 'cloudflared tunnel list' |
 | cloudflared.tunnelSecret | string | `"tunnel-credentials"` | name of secret with stored tunnel credentials |
 | extraEnv | list | `[]` | additional container environment variables |
+| arguments | list | `[]` | control cloudflared command-line parameters |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"cloudflare/cloudflared"` | overrides default image |

--- a/charts/cloudflare-tunnel/README.md
+++ b/charts/cloudflare-tunnel/README.md
@@ -58,7 +58,7 @@ For more settings of ingresses please consult [official cloudflare docs](https:/
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | affinity rules |
-| arguments | list | `["tunnel","--config","/etc/cloudflared/config/config.yaml","run"]` | cloudflared command line arguments |
+| cloudflared.arguments | list | `["tunnel","--config","/etc/cloudflared/config/config.yaml","run"]` | cloudflared command line arguments |
 | cloudflared.ingress | list | `[{"hostname":"hello.example.com","service":"hello_world"},{"service":"http_status:404"}]` | Yaml wth ingress rules |
 | cloudflared.serviceMonitor.enabled | bool | `false` |  |
 | cloudflared.tunnel | string | `nil` | tunnel UUID. Tunnel name will not work. Get it with 'cloudflared tunnel list' |

--- a/charts/cloudflare-tunnel/README.md
+++ b/charts/cloudflare-tunnel/README.md
@@ -1,6 +1,6 @@
 # cloudflare-tunnel
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.0](https://img.shields.io/badge/AppVersion-0.6.0-informational?style=flat-square)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.0](https://img.shields.io/badge/AppVersion-0.6.0-informational?style=flat-square)
 
 Manage and use cloudflare tunnels (also known as argo tunnels) on k8s cluster
 
@@ -58,12 +58,12 @@ For more settings of ingresses please consult [official cloudflare docs](https:/
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | affinity rules |
+| arguments | list | `["tunnel","--config","/etc/cloudflared/config/config.yaml","run"]` | cloudflared command line arguments |
 | cloudflared.ingress | list | `[{"hostname":"hello.example.com","service":"hello_world"},{"service":"http_status:404"}]` | Yaml wth ingress rules |
 | cloudflared.serviceMonitor.enabled | bool | `false` |  |
 | cloudflared.tunnel | string | `nil` | tunnel UUID. Tunnel name will not work. Get it with 'cloudflared tunnel list' |
 | cloudflared.tunnelSecret | string | `"tunnel-credentials"` | name of secret with stored tunnel credentials |
 | extraEnv | list | `[]` | additional container environment variables |
-| arguments | list | `[]` | control cloudflared command-line parameters |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"cloudflare/cloudflared"` | overrides default image |

--- a/charts/cloudflare-tunnel/templates/deployment.yaml
+++ b/charts/cloudflare-tunnel/templates/deployment.yaml
@@ -41,10 +41,9 @@ spec:
               containerPort: 2000
               protocol: TCP
           args:
-            - tunnel
-            - --config
-            - /etc/cloudflared/config/config.yaml
-            - run
+            {{  range .Values.arguments }}
+              - {{ . }}
+            {{ end }}
           livenessProbe:
             httpGet:
               # Cloudflared has a /ready endpoint which returns 200 if and only if

--- a/charts/cloudflare-tunnel/templates/deployment.yaml
+++ b/charts/cloudflare-tunnel/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
               containerPort: 2000
               protocol: TCP
           args:
-            {{  range .Values.arguments }}
+            {{  range .Values.cloudflared.arguments }}
               - {{ . }}
             {{ end }}
           livenessProbe:

--- a/charts/cloudflare-tunnel/values.yaml
+++ b/charts/cloudflare-tunnel/values.yaml
@@ -59,6 +59,14 @@ extraEnv: []
 ##     value: 6
 ##
 
+# -- cloudflared command line arguments
+arguments:
+  # https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/tunnel-guide/local/local-management/arguments/
+  - tunnel
+  - --config
+  - /etc/cloudflared/config/config.yaml
+  - run
+
 # -- pod security context
 podSecurityContext: {}
   # fsGroup: 2000

--- a/charts/cloudflare-tunnel/values.yaml
+++ b/charts/cloudflare-tunnel/values.yaml
@@ -39,6 +39,14 @@ cloudflared:
     - service: http_status:404
   serviceMonitor:
     enabled: false
+  # -- cloudflared command line arguments
+  arguments:
+    # https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/tunnel-guide/local/local-management/arguments/
+    - tunnel
+    - --config
+    - /etc/cloudflared/config/config.yaml
+    - run
+
 
 serviceAccount:
   # -- Specifies whether a service account should be created
@@ -58,14 +66,6 @@ extraEnv: []
 ##   - name: TUNNEL_EDGE_IP_VERSION
 ##     value: 6
 ##
-
-# -- cloudflared command line arguments
-arguments:
-  # https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/tunnel-guide/local/local-management/arguments/
-  - tunnel
-  - --config
-  - /etc/cloudflared/config/config.yaml
-  - run
 
 # -- pod security context
 podSecurityContext: {}

--- a/charts/cloudflare-tunnel/values.yaml
+++ b/charts/cloudflare-tunnel/values.yaml
@@ -10,7 +10,7 @@ image:
   repository: cloudflare/cloudflared
   pullPolicy: IfNotPresent
   # -- Overrides the image tag whose default is the chart appVersion.
-  tag: "2022.10.3"
+  tag: "2022.11.1"
 
 imagePullSecrets: []
 nameOverride: ""
@@ -46,7 +46,6 @@ cloudflared:
     - --config
     - /etc/cloudflared/config/config.yaml
     - run
-
 
 serviceAccount:
   # -- Specifies whether a service account should be created


### PR DESCRIPTION
### Description
This is a small change in order to be able to control cloudflared command line arguments upon chart deployment in `values.yaml`.
Currently, these parameters are hardcoded in the `deployments.yaml` file.

### Examples
For example you should be able to enable debug logging
```
arguments:
  - tunnel
  - --loglevel
  - debug
  - --config
  - /etc/cloudflared/config/config.yaml
  - run
```

or update protocol and set region to the desired one
```
arguments:
  - tunnel
  - -p
  - http2
  - --region
  - us
  - --config
  - /etc/cloudflared/config/config.yaml
  - run
```

and so on. A full list with all the available cloudflared options is available here: https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/tunnel-guide/local/local-management/arguments/#protocol

### Misc
Also, I was thinking to nest this option under the `cloudflared` key but I ended up putting it under root to keep it more generic. If you think otherwise I can change.

I have also 
- bumped Chart version
- updated the `README.md` file helm-docs https://github.com/norwoodj/helm-docs in chart directory