### PR TITLE
Refactoring labels

### DIFF
--- a/charts/pyrra/templates/_helpers.tpl
+++ b/charts/pyrra/templates/_helpers.tpl
@@ -39,7 +39,11 @@ helm.sh/chart: {{ include "pyrra.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
+app.kubernetes.io/component: metrics
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.additionalLabels }}
+{{ toYaml .Values.additionalLabels }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/pyrra/templates/servicemonitor.yaml
+++ b/charts/pyrra/templates/servicemonitor.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ template "pyrra.fullname" . }}-server
   labels:
     {{- include "pyrra.labels" . | nindent 4 }}
+    {{- if .Values.serviceMonitor.labels }}
+    {{- toYaml .Values.serviceMonitor.labels | nindent 4}}
+    {{- end }}
 spec:
   jobLabel: {{ .Values.serviceMonitor.jobLabel | quote }}
   selector:

--- a/charts/pyrra/values.yaml
+++ b/charts/pyrra/values.yaml
@@ -13,6 +13,9 @@ image:
   # -- Overrides the image tag
   tag: "v0.5.1"
 
+additionalLabels: {}
+  # app: pyrra
+
 serviceAccount:
   # -- Specifies whether a service account should be created
   create: true
@@ -80,3 +83,5 @@ tolerations: {}
 serviceMonitor:
   # -- enables servicemonitor for server monitoring
   enabled: false
+  # -- Set labels for the ServiceMonitor, use this to define your scrape label for Prometheus Operator
+  labels: {}


### PR DESCRIPTION
- Add missing label `app.kubernetes.io/component` from [Kubernetes recommanded labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/)
- Add labels for ServiceMonitor resource