### PR TITLE
feat(pyrra): added extraKubernetesArgs and extraApiArgs

### DIFF
--- a/charts/pyrra/Chart.yaml
+++ b/charts/pyrra/Chart.yaml
@@ -16,10 +16,10 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.8.0
+version: 0.9.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: v0.6.2
+appVersion: v0.6.4

--- a/charts/pyrra/README.md
+++ b/charts/pyrra/README.md
@@ -1,6 +1,6 @@
 # pyrra
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.6.2](https://img.shields.io/badge/AppVersion-v0.6.2-informational?style=flat-square)
+![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.6.4](https://img.shields.io/badge/AppVersion-v0.6.4-informational?style=flat-square)
 
 SLO manager and alert generator
 
@@ -13,6 +13,8 @@ Additionaly, you (most likely) will need to specify prometheusExternalUrl with U
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | additionalLabels | object | `{}` |  |
+| extraApiArgs | list | `[]` |  |
+| extraKubernetesArgs | list | `[]` |  |
 | fullnameOverride | string | `""` | Overrides helm-generated chart fullname |
 | genericRules.enabled | bool | `false` | enables generate Pyrra generic recording rules. Pyrra generates metrics with the same name for each SLO. |
 | image.pullPolicy | string | `"IfNotPresent"` | Overrides pullpolicy |

--- a/charts/pyrra/README.md
+++ b/charts/pyrra/README.md
@@ -13,8 +13,8 @@ Additionaly, you (most likely) will need to specify prometheusExternalUrl with U
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | additionalLabels | object | `{}` |  |
-| extraApiArgs | list | `[]` |  |
-| extraKubernetesArgs | list | `[]` |  |
+| extraApiArgs | list | `[]` | Extra args for Pyrra's API container |
+| extraKubernetesArgs | list | `[]` | Extra args for Pyrra's Kubernetes container |
 | fullnameOverride | string | `""` | Overrides helm-generated chart fullname |
 | genericRules.enabled | bool | `false` | enables generate Pyrra generic recording rules. Pyrra generates metrics with the same name for each SLO. |
 | image.pullPolicy | string | `"IfNotPresent"` | Overrides pullpolicy |

--- a/charts/pyrra/templates/deployment.yaml
+++ b/charts/pyrra/templates/deployment.yaml
@@ -35,6 +35,9 @@ spec:
             {{- if .Values.genericRules.enabled }}
             - --generic-rules
             {{- end }}
+            {{- with .Values.extraKubernetesArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
         - name: {{ .Chart.Name }}
@@ -48,6 +51,9 @@ spec:
             - --api-url=http://localhost:9444
             {{- if .Values.prometheusExternalUrl }}
             - --prometheus-external-url={{ .Values.prometheusExternalUrl }}
+            {{- end }}
+            {{- with .Values.extraApiArgs }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           ports:
           - name: http

--- a/charts/pyrra/values.yaml
+++ b/charts/pyrra/values.yaml
@@ -16,6 +16,11 @@ image:
 additionalLabels: {}
   # app: pyrra
 
+# Extra args for Pyrra's API container
+extraApiArgs: []
+# Extra args for Pyrra's Kubernetes container
+extraKubernetesArgs: []
+
 serviceAccount:
   # -- Specifies whether a service account should be created
   create: true

--- a/charts/pyrra/values.yaml
+++ b/charts/pyrra/values.yaml
@@ -16,9 +16,9 @@ image:
 additionalLabels: {}
   # app: pyrra
 
-# Extra args for Pyrra's API container
+# -- Extra args for Pyrra's API container
 extraApiArgs: []
-# Extra args for Pyrra's Kubernetes container
+# -- Extra args for Pyrra's Kubernetes container
 extraKubernetesArgs: []
 
 serviceAccount:


### PR DESCRIPTION
Changes:
- Added `extraKubernetesArgs` 
- Added `extraApiArgs`
- Bumped Pyrra to v0.6.4

Reason: 
- Need to use an unsupported flag, this is also future-proof.