### PR TITLE
fix(pyrra): generate jobLabel if not set explicitly

### DIFF
--- a/charts/pyrra/Chart.yaml
+++ b/charts/pyrra/Chart.yaml
@@ -16,10 +16,10 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.11.0
+version: 0.11.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: v0.7.1
+appVersion: v0.7.2

--- a/charts/pyrra/README.md
+++ b/charts/pyrra/README.md
@@ -1,6 +1,6 @@
 # pyrra
 
-![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.7.1](https://img.shields.io/badge/AppVersion-v0.7.1-informational?style=flat-square)
+![Version: 0.11.1](https://img.shields.io/badge/Version-0.11.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.7.2](https://img.shields.io/badge/AppVersion-v0.7.2-informational?style=flat-square)
 
 SLO manager and alert generator
 
@@ -19,7 +19,7 @@ Additionaly, you (most likely) will need to specify prometheusExternalUrl with U
 | genericRules.enabled | bool | `false` | enables generate Pyrra generic recording rules. Pyrra generates metrics with the same name for each SLO. |
 | image.pullPolicy | string | `"IfNotPresent"` | Overrides pullpolicy |
 | image.repository | string | `"ghcr.io/pyrra-dev/pyrra"` | Overrides the image repository |
-| image.tag | string | `"v0.7.1"` | Overrides the image tag |
+| image.tag | string | `"v0.7.2"` | Overrides the image tag |
 | imagePullSecrets | list | `[]` | specifies pull secrets for image repository |
 | ingress.annotations | object | `{}` | additional annotations for ingress |
 | ingress.className | string | `""` | specifies ingress class name (ie nginx) |

--- a/charts/pyrra/templates/servicemonitor.yaml
+++ b/charts/pyrra/templates/servicemonitor.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- toYaml .Values.serviceMonitor.labels | nindent 4}}
     {{- end }}
 spec:
-  jobLabel: {{ .Values.serviceMonitor.jobLabel | quote }}
+  jobLabel: {{ .Values.serviceMonitor.jobLabel | default (printf "%s-server" (include "pyrra.fullname" .)) }}
   selector:
     matchLabels:
       {{- include "pyrra.selectorLabels" . | nindent 6 }}

--- a/charts/pyrra/values.yaml
+++ b/charts/pyrra/values.yaml
@@ -11,7 +11,7 @@ image:
   # -- Overrides pullpolicy
   pullPolicy: IfNotPresent
   # -- Overrides the image tag
-  tag: "v0.7.1"
+  tag: "v0.7.2"
 
 additionalLabels: {}
   # app: pyrra
@@ -96,6 +96,8 @@ serviceMonitor:
   enabled: false
   # -- Set labels for the ServiceMonitor, use this to define your scrape label for Prometheus Operator
   labels: {}
+  # -- provides the possibility to override the jobName if needed
+  # jobLabel: fancy-pyrra-server
 
 genericRules:
   # -- enables generate Pyrra generic recording rules. Pyrra generates metrics with the same name for each SLO.


### PR DESCRIPTION
`Could not determine release state: unable to determine cluster state: ServiceMonitor/monitoring/pyrra-server dry-run failed (Invalid): ServiceMonitor.monitoring.coreos.com "pyrra-server" is invalid: spec.jobLabel: Invalid value: "null": spec.jobLabel in body must be of type string: "null"` - fix