### PR TITLE
chore(charts,pyrra): bump version from 'v0.8.0' to 'v0.8.1'

### DIFF
--- a/charts/pyrra/Chart.yaml
+++ b/charts/pyrra/Chart.yaml
@@ -16,10 +16,10 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.14.1
+version: 0.14.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: v0.8.0
+appVersion: v0.8.1

--- a/charts/pyrra/README.md
+++ b/charts/pyrra/README.md
@@ -1,6 +1,6 @@
 # pyrra
 
-![Version: 0.14.1](https://img.shields.io/badge/Version-0.14.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.8.0](https://img.shields.io/badge/AppVersion-v0.8.0-informational?style=flat-square)
+![Version: 0.14.2](https://img.shields.io/badge/Version-0.14.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.8.1](https://img.shields.io/badge/AppVersion-v0.8.1-informational?style=flat-square)
 
 SLO manager and alert generator
 
@@ -33,7 +33,7 @@ The dashboards can be deployed using a ConfigMap and get's automatically [reload
 | genericRules.enabled | bool | `false` | enables generate Pyrra generic recording rules. Pyrra generates metrics with the same name for each SLO. |
 | image.pullPolicy | string | `"IfNotPresent"` | Overrides pullpolicy |
 | image.repository | string | `"ghcr.io/pyrra-dev/pyrra"` | Overrides the image repository |
-| image.tag | string | `"v0.8.0"` | Overrides the image tag |
+| image.tag | string | `"v0.8.1"` | Overrides the image tag |
 | imagePullSecrets | list | `[]` | specifies pull secrets for image repository |
 | ingress.annotations | object | `{}` | additional annotations for ingress |
 | ingress.className | string | `""` | specifies ingress class name (ie nginx) |

--- a/charts/pyrra/values.yaml
+++ b/charts/pyrra/values.yaml
@@ -11,7 +11,7 @@ image:
   # -- Overrides pullpolicy
   pullPolicy: IfNotPresent
   # -- Overrides the image tag
-  tag: "v0.8.0"
+  tag: "v0.8.1"
 
 additionalLabels: {}
   # app: pyrra


### PR DESCRIPTION
@rlex it seams so that there weren't any crd changes in https://github.com/pyrra-dev/pyrra/blob/main/jsonnet/controller-gen/pyrra.dev_servicelevelobjectives.json