### PR TITLE
feat: add support for route-prefix

### DIFF
--- a/charts/pyrra/Chart.yaml
+++ b/charts/pyrra/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.14.2
+version: 0.14.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/pyrra/README.md
+++ b/charts/pyrra/README.md
@@ -1,6 +1,6 @@
 # pyrra
 
-![Version: 0.14.2](https://img.shields.io/badge/Version-0.14.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.8.1](https://img.shields.io/badge/AppVersion-v0.8.1-informational?style=flat-square)
+![Version: 0.14.3](https://img.shields.io/badge/Version-0.14.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.8.1](https://img.shields.io/badge/AppVersion-v0.8.1-informational?style=flat-square)
 
 SLO manager and alert generator
 
@@ -53,6 +53,7 @@ The dashboards can be deployed using a ConfigMap and get's automatically [reload
 | prometheusRule.pyrraReconciliationError.severity | string | `"warning"` | Set severity for PyrraReconciliationError alert |
 | prometheusUrl | string | `"http://prometheus-operated.monitoring.svc.cluster.local:9090"` | url to prometheus instance with metrics |
 | resources | object | `{}` | resource limits and requests for server pod |
+| routePrefix | string | `""` | Must start with a slash and not end with a slash. |
 | securityContext | object | `{}` | additional security context for server |
 | service.annotations | object | `{}` | Annotations to add to the service |
 | service.nodePort | string | `""` | node port for HTTP, choose port between <30000-32767> |

--- a/charts/pyrra/templates/deployment.yaml
+++ b/charts/pyrra/templates/deployment.yaml
@@ -66,6 +66,9 @@ spec:
             {{- if .Values.prometheusExternalUrl }}
             - --prometheus-external-url={{ .Values.prometheusExternalUrl }}
             {{- end }}
+            {{- if .Values.routePrefix }}
+            - --route-prefix={{ .Values.routePrefix }}
+            {{- end }}
             {{- with .Values.extraApiArgs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/pyrra/templates/servicemonitor-server.yaml
+++ b/charts/pyrra/templates/servicemonitor-server.yaml
@@ -18,6 +18,9 @@ spec:
     - {{ .Release.Namespace }}
   endpoints:
   - port: http
+    {{- if .Values.routePrefix }}
+    path: {{ .Values.routePrefix }}/metrics
+    {{- end }}
     {{- if .Values.serviceMonitor.interval }}
     interval: {{ .Values.serviceMonitor.interval }}
     {{- end }}

--- a/charts/pyrra/templates/tests/test-connection.yaml
+++ b/charts/pyrra/templates/tests/test-connection.yaml
@@ -11,5 +11,20 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['{{ include "pyrra.fullname" . }}:{{ .Values.service.port }}']
+      {{- if .Values.routePrefix }}
+      args: ['-O-', '{{ include "pyrra.fullname" . }}:{{ .Values.service.port }}{{ .Values.routePrefix }}']
+      {{- else }}
+      args: ['-O-', '{{ include "pyrra.fullname" . }}:{{ .Values.service.port }}']
+      {{- end }}
+      securityContext:
+        readOnlyRootFilesystem: true
+        allowPrivilegeEscalation: false
+        privileged: false
+        capabilities:
+          drop:
+            - ALL
   restartPolicy: Never
+  securityContext:
+    runAsUser: 65534
+    runAsGroup: 65534
+    runAsNonRoot: true

--- a/charts/pyrra/templates/tests/test-connection.yaml
+++ b/charts/pyrra/templates/tests/test-connection.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   containers:
     - name: wget
-      image: busybox
+      image: busybox:1.37
       command: ['wget']
       {{- if .Values.routePrefix }}
       args: ['-O-', '{{ include "pyrra.fullname" . }}:{{ .Values.service.port }}{{ .Values.routePrefix }}']

--- a/charts/pyrra/values.yaml
+++ b/charts/pyrra/values.yaml
@@ -44,6 +44,10 @@ prometheusUrl: http://prometheus-operated.monitoring.svc.cluster.local:9090
 # -- url to public-facing prometheus UI in case it differs from prometheusUrl
 prometheusExternalUrl: ""
 
+# -- url under which the pyrra web server is serving content. this can be set when running behind a reverse proxy.
+# -- Must start with a slash and not end with a slash.
+routePrefix: ""
+
 service:
   # -- Annotations to add to the service
   annotations: {}


### PR DESCRIPTION
**Description**
This PR adds support to configure the Pyrra `--route-prefix` argument on the Pyrra web-server. This is useful when the Pyrra UI is running behind a reverse proxy or more generally under a different path.

If the new property `.Values.routePrefix` is set:
- Pass argument to web-server via Deployment manifest
- Adjust ServiceMonitor path to include routePrefix
- Adjust test-connection to include routePrefix

Extra:
- Add security context to test-connection pod to be able to run in more restrictive environments. Do not run as root. Run as user nobody. Setting readOnlyRootFs requires wget to write to stdout.

This also fixes: https://github.com/rlex/helm-charts/issues/158

**How I tested this change**
Update values.yaml:
```yaml
routePrefix: "/pyrra"
serviceMonitor:
  enabled: true
```

Render the chart:
```
helm template --name-template pyrra --values values.yaml .
```

Deployment:
```yaml
---
# Source: pyrra/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: pyrra
  labels:
    helm.sh/chart: pyrra-0.14.3
    app.kubernetes.io/name: pyrra
    app.kubernetes.io/instance: pyrra
    app.kubernetes.io/version: "v0.8.1"
    app.kubernetes.io/component: metrics
    app.kubernetes.io/managed-by: Helm
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: pyrra
      app.kubernetes.io/instance: pyrra
  template:
    metadata:
      labels:
        app.kubernetes.io/name: pyrra
        app.kubernetes.io/instance: pyrra
    spec:
      serviceAccountName: pyrra
      securityContext:
        {}
      containers:
        - name: pyrra-kubernetes
          securityContext:
            {}
          image: "ghcr.io/pyrra-dev/pyrra:v0.8.1"
          imagePullPolicy: IfNotPresent
          args:
            - kubernetes
            - --metrics-addr=:8080
          resources:
            {}
          ports:
            - name: op-metrics
              containerPort: 8080
        - name: pyrra
          securityContext:
            {}
          image: "ghcr.io/pyrra-dev/pyrra:v0.8.1"
          imagePullPolicy: IfNotPresent
          args:
            - api
            - --prometheus-url=http://prometheus-operated.monitoring.svc.cluster.local:9090
            - --api-url=http://localhost:9444
            - --route-prefix=/pyrra
          ports:
          - name: http
            containerPort: 9099
```

ServiceMonitor:
```yaml
---
# Source: pyrra/templates/servicemonitor-server.yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: pyrra-server
  labels:
    helm.sh/chart: pyrra-0.14.3
    app.kubernetes.io/name: pyrra
    app.kubernetes.io/instance: pyrra
    app.kubernetes.io/version: "v0.8.1"
    app.kubernetes.io/component: metrics
    app.kubernetes.io/managed-by: Helm
spec:
  jobLabel: pyrra-server
  selector:
    matchLabels:
      app.kubernetes.io/name: pyrra
      app.kubernetes.io/instance: pyrra
  namespaceSelector:
    matchNames:
    - monitoring
  endpoints:
  - port: http
    path: /pyrra/metrics
```

test-connection pod:
```yaml
---
# Source: pyrra/templates/tests/test-connection.yaml
apiVersion: v1
kind: Pod
metadata:
  name: "pyrra-test-connection"
  labels:
    helm.sh/chart: pyrra-0.14.3
    app.kubernetes.io/name: pyrra
    app.kubernetes.io/instance: pyrra
    app.kubernetes.io/version: "v0.8.1"
    app.kubernetes.io/component: metrics
    app.kubernetes.io/managed-by: Helm
  annotations:
    "helm.sh/hook": test
spec:
  containers:
    - name: wget
      image: busybox
      command: ['wget']
      args: ['-O-', 'pyrra:9099']
      securityContext:
        readOnlyRootFilesystem: true
        allowPrivilegeEscalation: false
        privileged: false
        capabilities:
          drop:
            - ALL
  restartPolicy: Never
  securityContext:
    runAsUser: 65534
    runAsGroup: 65534
    runAsNonRoot: true
```